### PR TITLE
fix: improve performance, allow further processing

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,15 +1,24 @@
+/**
+ *
+ * @param babel {import('@babel/core')}
+*/
 module.exports = function removeNodePrefix(babel) {
   return {
     name: 'remove-node-prefix',
     visitor: {
+      /**
+       * @param path {import('@babel/traverse').NodePath<import('@babel/types').StringLiteral>}
+      */
       StringLiteral(path) {
         if (
-          path.parent.type === 'ImportDeclaration' ||
+          (path.parent.type === 'ImportDeclaration' ||
           (path.parent.type === 'CallExpression' &&
-            path.parent.callee.name === 'require')
+            path.parent.callee.name === 'require')) &&
+            path.node.value.startsWith('node:')
         ) {
+          // remove node: prefix from the path
           path.replaceWith(
-            babel.types.stringLiteral(path.node.value.replace(/^node:/, '')),
+            babel.types.stringLiteral(path.node.value.slice(5)),
           );
         }
         path.skip();

--- a/index.js
+++ b/index.js
@@ -21,7 +21,6 @@ module.exports = function removeNodePrefix(babel) {
             babel.types.stringLiteral(path.node.value.slice(5)),
           );
         }
-        path.skip();
       },
     },
   };

--- a/index.js
+++ b/index.js
@@ -1,25 +1,22 @@
 /**
- *
  * @param babel {import('@babel/core')}
-*/
+ */
 module.exports = function removeNodePrefix(babel) {
   return {
     name: 'remove-node-prefix',
     visitor: {
       /**
        * @param path {import('@babel/traverse').NodePath<import('@babel/types').StringLiteral>}
-      */
+       */
       StringLiteral(path) {
-        if (
-          (path.parent.type === 'ImportDeclaration' ||
+        const isImportOrRequire =
+          path.parent.type === 'ImportDeclaration' ||
           (path.parent.type === 'CallExpression' &&
-            path.parent.callee.name === 'require')) &&
-            path.node.value.startsWith('node:')
-        ) {
-          // remove node: prefix from the path
-          path.replaceWith(
-            babel.types.stringLiteral(path.node.value.slice(5)),
-          );
+            path.parent.callee.name === 'require');
+
+        if (isImportOrRequire && path.node.value.startsWith('node:')) {
+          // Remove `node:` prefix from the path
+          path.replaceWith(babel.types.stringLiteral(path.node.value.slice(5)));
         }
       },
     },


### PR DESCRIPTION
- fix: faster the node path update string:
This replaces regex with a simple `startsWith` check that skips replacing of many string literals

- fix: allow processing of the string literals with other plugins


This package can be used for fixing https://github.com/parcel-bundler/parcel/issues/8049
